### PR TITLE
Skip upload interstitial and update Media Tools branding

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
-    <title>Image Tools</title>
+    <title>Media Tools</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.24",
+  "version": "2.5.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.24",
+      "version": "2.5.25",
       "dependencies": {
         "@ffmpeg/ffmpeg": "^0.12.4",
         "@ffmpeg/util": "^0.12.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.24",
+  "version": "2.5.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,12 +4,10 @@ import ImageConverter from './ImageConverter.jsx';
 import VideoConverter from './VideoConverter.jsx';
 
 function App() {
-  const [mode, setMode] = useState(null);
   const [initImages, setInitImages] = useState(null);
   const [initVideo, setInitVideo] = useState(null);
 
   const resetHome = () => {
-    setMode(null);
     setInitImages(null);
     setInitVideo(null);
   };
@@ -18,7 +16,6 @@ function App() {
     const files = e.target.files;
     if (files && files.length) {
       setInitImages(files);
-      setMode('image');
     }
     e.target.value = '';
   };
@@ -27,15 +24,14 @@ function App() {
     const file = e.target.files[0];
     if (file) {
       setInitVideo(file);
-      setMode('video');
     }
     e.target.value = '';
   };
 
-  if (mode === 'image') {
+  if (initImages) {
     return <ImageConverter onHome={resetHome} initialFiles={initImages} />;
   }
-  if (mode === 'video') {
+  if (initVideo) {
     return <VideoConverter onHome={resetHome} initialFile={initVideo} />;
   }
 


### PR DESCRIPTION
## Summary
- Jump directly into conversion by rendering tool screens only when a file is selected.
- Rename app title to **Media Tools** and bump package version to 2.5.25.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fb2ab1d7883278b925c8dee857f37