### PR TITLE
Fix initial image selection resetting

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,8 +13,8 @@ function App() {
   };
 
   const handleHomeImage = (e) => {
-    const files = e.target.files;
-    if (files && files.length) {
+    const files = Array.from(e.target.files || []);
+    if (files.length) {
       setInitImages(files);
     }
     e.target.value = '';


### PR DESCRIPTION
## Summary
- preserve selected images when leaving home screen to avoid extra upload step

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fb638728c8327981bcb84af7d7291