### PR TITLE
feat: show video upload and conversion progress

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -281,6 +281,22 @@
   animation: spin 1s linear infinite;
 }
 
+.loading-progress {
+  width: 80%;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 3px;
+  margin-top: 0.5em;
+  overflow: hidden;
+}
+
+.loading-progress div {
+  height: 100%;
+  background: #646cff;
+  width: 0;
+  transition: width 0.2s;
+}
+
 .loading-text {
   margin-top: 0.5em;
   font-size: 0.9em;


### PR DESCRIPTION
## Summary
- display upload and conversion progress percentages during video processing
- add a progress bar overlay in the video converter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fbdc1c11c8327acb8d8fd4fb9d99c