### PR TITLE
feat: enhance conversion overlay and mkv support

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -268,8 +268,34 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(8px);
   z-index: 1000;
+}
+
+.video-loading {
+  justify-content: flex-start;
+  padding: 1rem;
+}
+
+.video-loading .loading-video {
+  width: 100%;
+  max-width: 480px;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.video-loading .loading-progress {
+  width: 100%;
+  max-width: 480px;
+  margin-top: auto;
+  margin-bottom: 1rem;
+}
+
+.video-loading .loading-text {
+  margin-top: 1rem;
+  margin-bottom: 0.5em;
+  text-align: center;
 }
 
 .spinner {


### PR DESCRIPTION
## Summary
- add blurred black conversion overlay with video preview and bottom progress bar
- display estimated remaining time during conversion
- handle mkv input by preserving original extension for ffmpeg

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fc0ce1a948327ba6e084396af0f3c