### PR TITLE
Improve video processing and MKV upload support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.25",
+  "version": "2.5.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.25",
+      "version": "2.5.26",
       "dependencies": {
         "@ffmpeg/ffmpeg": "^0.12.4",
         "@ffmpeg/util": "^0.12.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.25",
+  "version": "2.5.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/VideoConverter.jsx
+++ b/frontend/src/VideoConverter.jsx
@@ -151,7 +151,7 @@ export default function VideoConverter({ onHome, initialFile }) {
   const handleMainDownload = () => {
     const preset = {
       ...qualityPresets.medium,
-      video: { ...qualityPresets.medium.video, resolution: 'original' },
+      video: { ...qualityPresets.medium.video, resolution: 'original', preset: 'fast' },
     };
     convert(preset);
   };
@@ -232,7 +232,7 @@ export default function VideoConverter({ onHome, initialFile }) {
         id="video-input"
         ref={fileInputRef}
         type="file"
-        accept="video/*"
+        accept="video/*,.mkv"
         onChange={handleFileChange}
         style={{ display: 'none' }}
       />
@@ -266,7 +266,7 @@ export default function VideoConverter({ onHome, initialFile }) {
             <div className="preview-wrapper active">
               <video
                 src={videoURL}
-                className="preview-img active"
+                className="preview-img active" controls
                 playsInline
                 onClick={(e) => {
                   const vid = e.target;
@@ -298,15 +298,6 @@ export default function VideoConverter({ onHome, initialFile }) {
       )}
       {loading && (
         <div className="loading-overlay video-loading fade-in">
-          {videoURL && (
-            <video
-              src={videoURL}
-              className="loading-video"
-              controls
-              autoPlay
-              muted
-            />
-          )}
           <div className="loading-text">
             {stage} {progress}%
             {eta && ` · ETA ${eta}`}


### PR DESCRIPTION
## Summary
- support MKV files during upload and add playback controls while removing duplicate loading preview
- use a faster preset for quicker conversions
- bump frontend version to 2.5.26

## Testing
- `npm test --prefix frontend` *(fails: Missing script: "test")*
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688fc371ddec83279dc071c3cad2656e