### PR TITLE
feat: add server fallback and scrollable process logs

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -417,3 +417,13 @@
   font-size: 0.7rem;
   color: rgba(255, 255, 255, 0.4);
 }
+
+.process-log {
+  max-height: 8rem;
+  overflow-y: auto;
+  text-align: left;
+  margin-top: 1rem;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- add client-side check and fallback to server processing when stream capture unsupported
- add process log with auto-scroll styling for better UX

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fc2a4b2fc83279f99de63816d50a1